### PR TITLE
Removes range limit from electrodes.

### DIFF
--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -18,7 +18,7 @@
 	stutter = 5
 	jitter = 20
 	hitsound = 'sound/weapons/taserhit.ogg'
-	range = 7
+	
 
 /obj/item/projectile/energy/electrode/on_hit(atom/target, blocked = FALSE)
 	. = ..()


### PR DESCRIPTION
[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)
[]: # (See here for how to easily make a changelog: https://github.com/tgstation/tgstation/wiki/Changelogs. An example changelog has been provided below. Please edit or remove)


:cl: optional name here
del: Removed the range limit on electrodes.
/:cl:

[why]: # Removed the range limit on electrodes, as per Asskek's request. Step one towards old ss13 balance.
